### PR TITLE
Ellided response type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "axum-autoroute"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "axum-autoroute-macros",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "axum-autoroute-example"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "axum-autoroute",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "axum-autoroute-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,8 @@ all-features = true
 yanked = "deny"
 unmaintained = "all"
 ignore = [
-    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained, but still used by utoipa-axum, it is only used for code generation through macro rules, it is probably not an issue that it is not maintained." }
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained, but still used by utoipa-axum, it is only used for code generation through macro rules, it is probably not an issue that it is not maintained. Issue opened: https://github.com/juhaku/utoipa/issues/1563" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained, but is still used by axum-typed-multipart. Issue opened: https://github.com/murar8/axum_typed_multipart/issues/128" }
 ]
 
 [bans]

--- a/example/src/routes/hello.rs
+++ b/example/src/routes/hello.rs
@@ -24,7 +24,7 @@ async fn hello_route() -> HelloRouteResponses {
         (IM_A_TEAPOT, body=String, serializer=NONE),
     ]
 )]
-async fn no_description() -> NoDescriptionResponses {
+async fn no_description() -> _ {
     "Hello World!".to_string().into_im_a_teapot()
 }
 
@@ -34,7 +34,7 @@ async fn no_description() -> NoDescriptionResponses {
         (IM_A_TEAPOT, body=String, serializer=NONE, description="Always says bonjour"),
     ]
 )]
-async fn bonjour_secret_route() -> BonjourSecretRouteResponses {
+async fn bonjour_secret_route() -> _ {
     "Bonjour World !".to_string().into_im_a_teapot()
 }
 
@@ -44,7 +44,7 @@ async fn bonjour_secret_route() -> BonjourSecretRouteResponses {
         (IM_A_TEAPOT, body=String, serializer=NONE, description="Always says bye"),
     ]
 )]
-async fn bye_secret_route() -> ByeSecretRouteResponses {
+async fn bye_secret_route() -> _ {
     "Bye World!".to_string().into_im_a_teapot()
 }
 

--- a/example/src/routes/main_example.rs
+++ b/example/src/routes/main_example.rs
@@ -45,7 +45,8 @@ async fn my_route(
     Path(path): Path<PathParam>,     // path extraction
     Query(query): Query<QueryParam>, // query extraction
     Json(json): Json<JsonRequest>,   // json body extraction
-) -> MyRouteResponses {
+) -> MyRouteResponses // the response type can also be elided (`_`)
+{
     if path.id % 2 != 0 {
         // a response can be returned by using an into_... function corresponding to the http return code
         // (here `IntoBadRequest` which exposes the functions `into_bad_request` and `into_400`)
@@ -55,7 +56,7 @@ async fn my_route(
             id: path.id,
             text1: query.text1,
             text2: json.text2,
-        };        
+        };
         resp.into_200()
     }
 }

--- a/example/src/test_utils.rs
+++ b/example/src/test_utils.rs
@@ -82,7 +82,7 @@ macro_rules! assert_traces {
 pub(crate) use assert_traces;
 
 #[cfg(feature = "tracing")]
-pub fn check_traces(ref_filename: &str, lines: &Vec<String>) -> Result<(), String> {
+pub fn check_traces(ref_filename: &str, lines: &[String]) -> Result<(), String> {
     let content = lines
         .iter()
         .map(|s| strip_trace_datetime(s).to_string())

--- a/example/tests/compile_errors/05_bad_return_type.stderr
+++ b/example/tests/compile_errors/05_bad_return_type.stderr
@@ -1,4 +1,4 @@
-error: autoroute macro failed: expecting return type `MissingReturnResponses`
+error: autoroute macro failed: expecting return type to be either `MissingReturnResponses` or elided (`_`)
  --> tests/compile_errors/05_bad_return_type.rs:3:1
   |
 3 | #[autoroute(GET, path="/home", responses=[(200, body=String, description="response description")])]
@@ -6,7 +6,7 @@ error: autoroute macro failed: expecting return type `MissingReturnResponses`
   |
   = note: this error originates in the attribute macro `autoroute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: autoroute macro failed: expecting return type `BadReturnResponses`
+error: autoroute macro failed: expecting return type to be either `BadReturnResponses` or elided (`_`)
  --> tests/compile_errors/05_bad_return_type.rs:7:20
   |
 7 | fn bad_return() -> Test {}

--- a/macros/src/codegen/mod.rs
+++ b/macros/src/codegen/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod route_info;
 #[cfg(feature = "tracing")]
 pub(crate) mod tracing;
 pub(crate) mod trait_checkers;
-pub(crate) mod utoipa;
 pub(crate) mod trait_use;
+pub(crate) mod utoipa;

--- a/macros/src/codegen/trait_use.rs
+++ b/macros/src/codegen/trait_use.rs
@@ -3,14 +3,13 @@ use std::ops::Deref;
 use quote::quote_spanned;
 use syn::{Stmt, parse_quote_spanned};
 
-use crate::{AutorouteInput, codegen::responses::response_into_status_trait_name};
-
+use crate::AutorouteInput;
+use crate::codegen::responses::response_into_status_trait_name;
 
 /// Add use of Into... traits at the beginning of each autoroute handler
 pub fn add_use_traits(input: &mut AutorouteInput) {
     let mut use_traits = Vec::new();
     for response in input.meta.responses.deref() {
-
         let trait_name = response_into_status_trait_name(response);
         use_traits.push(quote_spanned! {response.status_code.span()=>
             use axum_autoroute::status_trait::#trait_name;

--- a/macros/src/macros_internal.rs
+++ b/macros/src/macros_internal.rs
@@ -83,14 +83,25 @@ fn check_func_return_type(input: &AutorouteInput) -> syn::Result<()> {
     let expected_name = responses_enum_name(input);
     let func_return = &input.itemfn.sig.output;
     let mut err_span = func_return.span();
+
     if let ReturnType::Type(_, box_type) = func_return {
         err_span = box_type.span();
-        if let Type::Path(path) = &**box_type
-            && let Some(ident) = path.path.get_ident()
-            && *ident == expected_name
-        {
-            return Ok(());
+        match &**box_type {
+            // named return type, check it matches
+            Type::Path(path) => {
+                if let Some(ident) = path.path.get_ident()
+                    && *ident == expected_name
+                {
+                    return Ok(());
+                }
+            }
+            // elided return type (_) is allowed
+            Type::Infer(_) => {
+                return Ok(());
+            }
+            // otherwise do nothing, an error will be raised
+            _ => (),
         }
     }
-    syn_bail!(err_span, "expecting return type `{expected_name}`")
+    syn_bail!(err_span, "expecting return type to be either `{expected_name}` or elided (`_`)")
 }


### PR DESCRIPTION
Allow elided return type (`_`) for autoroute functions.
See: https://github.com/Evolis-SA/axum-autoroute/issues/13